### PR TITLE
sink option seems to give errors, read the response and print it

### DIFF
--- a/src/Command/Dump.php
+++ b/src/Command/Dump.php
@@ -79,13 +79,17 @@ class Dump extends Command
                 'Transfer-Encoding' => 'chunked',
             ],
             RequestOptions::JSON => $data,
-            RequestOptions::SINK => STDOUT,
         ]);
+        if (200 !== $response->getStatusCode()) {
+            throw new \RuntimeException('Error '.$response->getStatusCode()."\n".$response->getBody()->getContents());
+        }
+
+        $output->write($response->getBody()->getContents());
 
         if ($output instanceof ConsoleOutputInterface && $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
             $output->getErrorOutput()->writeln(sprintf(
                 'Dumped <info>%s</info> bytes (gzip) from queue <info>%s</info>',
-                $response->getHeaderLine('x-encoded-content-length'),
+                $response->hasHeader('x-encoded-content-length') ? $response->getHeaderLine('x-encoded-content-length') : 'unspecified',
                 $queueName
             ));
         }


### PR DESCRIPTION
with sink, some systems ran into `Unable to seek to stream position 0 with whence 0`